### PR TITLE
fix: "theme.css" also modifying other sites' content

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,15 +15,24 @@
     "48": "src/img/wts_icon_48.png",
     "128": "src/img/wts_icon_128.png"
   },
-  "permissions": 
-  ["activeTab",
+  "permissions": [
+    "activeTab",
     "contextMenus",
-    "storage"],
-    
-  "content_scripts": [{
-    "js": ["src/js/content.js", "src/js/jspdf.js"],
-    "matches": ["<all_urls>"],
-    "css":     ["src/css/theme.css"],
-    "all_frames": true
-  }]
+    "storage"
+  ],
+  "content_scripts": [
+    {
+      "js": [
+        "src/js/content.js",
+        "src/js/jspdf.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "css": [
+        "src/css/content.css"
+      ],
+      "all_frames": true
+    }
+  ]
 }

--- a/src/css/content.css
+++ b/src/css/content.css
@@ -1,0 +1,32 @@
+.transcription-container {
+  bottom : 5%;
+  left : 0;
+  text-align : center;
+  background-color : rgba(0,0,0,0.8);
+  position :absolute;
+  color : rgba(255, 255, 255, 0.97);
+  padding : 10px;
+  font-size : 20px;
+  width : 50%;
+  transform : translate(50%);
+  border : 2px solid white;
+  border-radius: 5px;
+  z-index:  10000;
+  font-family:  "Arial";
+}
+
+.transcription-container-fullscreen {
+  bottom : 5%;
+  left : 0;
+  text-align : center;
+  background-color : transparent;
+  position :absolute;
+  color : rgba(255, 255, 255, 0.97);
+  padding : 10px;
+  font-size : 20px;
+  width : 50%;
+  transform : translate(50%);
+  border : none;
+  z-index:  10000;
+  font-family:  "Arial";
+}

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -59,7 +59,7 @@ h2 {
     position: relative;
     margin-bottom: 1em;
   }
-  
+
   select{
     border: 1px solid lightgrey;
     font-size: 12px;
@@ -68,7 +68,7 @@ h2 {
     padding: 1em;
     border: 1px solid #ccc;
   }
-  
+
   .language-select-element:after{
     content: '<>';
     font: 14px "Consolas", monospace;
@@ -82,37 +82,4 @@ h2 {
     border-bottom: 1px solid #999;
     position: absolute;
     pointer-events: none;
-  }
-
-  .transcription-container {
-    bottom : 5%;
-    left : 0;
-    text-align : center;
-    background-color : rgba(0,0,0,0.8);
-    position :absolute;
-    color : rgba(255, 255, 255, 0.97);
-    padding : 10px;
-    font-size : 20px;
-    width : 50%;
-    transform : translate(50%);
-    border : 2px solid white;
-    border-radius: 5px;
-    z-index:  10000;
-    font-family:  "Arial";
-  }
-
-  .transcription-container-fullscreen {
-    bottom : 5%;
-    left : 0;
-    text-align : center;
-    background-color : transparent;
-    position :absolute;
-    color : rgba(255, 255, 255, 0.97);
-    padding : 10px;
-    font-size : 20px;
-    width : 50%;
-    transform : translate(50%);
-    border : none;
-    z-index:  10000;
-    font-family:  "Arial";
   }

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="css/icons.css">
-        <link rel="stylesheet" href="css/theme.css">
+        <link rel="stylesheet" href="css/popup.css">
     </head>
     <body>
         <h2>What They Say</h2>


### PR DESCRIPTION
Some sites were being affected by the extension's `theme.css` file, since it was being included into the host page via `manifest.json` file.

Screenshot:
<img width="1303" alt="screen shot 2018-10-30 at 19 22 24" src="https://user-images.githubusercontent.com/11931916/47755198-33540580-dc7c-11e8-83c8-a32a9a516729.png">

I just moved the styles needed by the host page to a new file called `content.css`, which is now being injected by the `manifest.json` (`content_scripts` values).